### PR TITLE
Make coverage call more platform-agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+COVERAGE = $(or $(shell which coverage), $(shell which python-coverage), coverage)
+
 setup:
 	@pip install -Ue.\[tests\]
 
 test:
-	@coverage run --branch `which nosetests` -v --with-yanc -s tests/
+	@$(COVERAGE) run --branch `which nosetests` -v --with-yanc -s tests/
 
 coverage:
-	@coverage report -m --fail-under=30
+	@$(COVERAGE) report -m --fail-under=30
 
 focus:
-	@coverage run --branch `which nosetests` -vv --with-yanc --logging-level=WARNING --with-focus -i -s tests/
+	@$(COVERAGE) run --branch `which nosetests` -vv --with-yanc --logging-level=WARNING --with-focus -i -s tests/


### PR DESCRIPTION
This allows the Makefile to work on debian where coverage
was installed via the python-coverage debian package.