### PR TITLE
Ignore sentry package parsing error

### DIFF
--- a/remotecv/error_handler.py
+++ b/remotecv/error_handler.py
@@ -26,7 +26,7 @@ class ErrorHandler:
                 res_mod = pkg_resources.get_distribution(module)
                 if res_mod is not None:
                     resolved[module] = res_mod.version
-            except pkg_resources.DistributionNotFound:
+            except Exception:
                 pass
 
         return resolved


### PR DESCRIPTION
Like in the problem with thumbor and sentry: https://github.com/thumbor/thumbor/pull/757, we have to do the same in remotecv or fails the use.

Related: https://github.com/APSL/docker-thumbor/issues/36
