### PR TITLE
Update argparse limit (fixes #15)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ remotecv is an OpenCV worker for facial and feature recognition
     },
 
     install_requires=[
-        "argparse>=1.2.1,<1.3.0",
+        "argparse>=1.2.1,<1.5.0",
         "pyres>=1.5,<1.6",
         "Pillow>=4.3.0,<5.2.0",
     ],


### PR DESCRIPTION
* together with previous updates, version dependencies should fix #15 as well as https://github.com/thumbor/thumbor/issues/881
* I checked the [changelog](https://github.com/ThomasWaldmann/argparse/blob/master/NEWS.txt) and couldn't find any potential issues that we should worry about when upgrading
* I tested running remotecv after upgrading argparse manually `python -m remotecv.worker --host $REMOTECV_REDIS_HOST --port $REMOTECV_REDIS_PORT --database $REMOTECV_REDIS_DATABASE` and it seems to work as expected