### PR TITLE
Add https_loader

### DIFF
--- a/remotecv/https_loader.py
+++ b/remotecv/https_loader.py
@@ -1,0 +1,8 @@
+import urllib2
+import re
+
+def load_sync(path):
+    if not re.match(r'^http?', path):
+        path = 'https://%s' % path
+    path = urllib2.unquote(path)
+    return urllib2.urlopen(path).read()


### PR DESCRIPTION
This loader defaults to using the `https` protocol if none is specified in the url and uses the specified protocol in other cases.

I want/need this since urllib2 doesn't follow redirect per default. 

Fixes #20 