### PR TITLE
ModuleNotFoundError: No module named 'sentry_sdk'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.7"
 pyres = "^1.5"
 Pillow = "^7.0.0"
 opencv-python-headless = "^4.2.0"
+sentry-sdk = "^0.14.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"
@@ -22,7 +23,6 @@ black = "^19.10b0"
 preggy = "^1.4.4"
 pytest-cov = "^2.8.1"
 celery = "^4.4.1"
-sentry-sdk = "^0.14.2"
 
 [tool.poetry.scripts]
 remotecv = 'remotecv.worker:main'

--- a/setup.py
+++ b/setup.py
@@ -37,15 +37,15 @@ setup(
     },
     install_requires=[
         'opencv-python-headless==4.*,>=4.2.0', 'pillow==7.*,>=7.0.0',
-        'pyres==1.*,>=1.5.0'
+        'pyres==1.*,>=1.5.0', 'sentry-sdk==0.*,>=0.14.2'
     ],
     extras_require={
         "dev": [
-            "black==19.*,>=19.10.0", "celery==4.*,>=4.4.1",
+            "black==19.*,>=19.10.0.b0", "celery==4.*,>=4.4.1",
             "flake8==3.*,>=3.7.9", "preggy==1.*,>=1.4.4", "pylint==2.*,>=2.4.4",
             "pytest==5.*,>=5.3.5", "pytest-asyncio==0.*,>=0.10.0",
             "pytest-cov==2.*,>=2.8.1", "pytest-tldr==0.*,>=0.2.1",
-            "pytest-xdist==1.*,>=1.31.0", "sentry-sdk==0.*,>=0.14.2"
+            "pytest-xdist==1.*,>=1.31.0"
         ]
     },
 )


### PR DESCRIPTION
```bash
root@176e6491bcea:~# remotecv

Traceback (most recent call last):
  File "/venv/bin/remotecv", line 5, in <module>
    from remotecv.worker import main
  File "/venv/lib/python3.9/site-packages/remotecv/worker.py", line 18, in <module>
    from remotecv.error_handler import ErrorHandler
  File "/venv/lib/python3.9/site-packages/remotecv/error_handler.py", line 5, in <module>
    import sentry_sdk
ModuleNotFoundError: No module named 'sentry_sdk'
```

Installed packages (dephell is dead!):

```
aiofiles==0.5.0
aiohttp==3.6.2
aioresponses==0.6.3
aiosignal==1.2.0
amqp==2.5.2
apipkg==1.5
appdirs==1.4.3
astroid==2.3.3
async-timeout==3.0.1
attrs==19.3.0
autopep8==1.5.2
billiard==3.6.3.0
black==19.10b0
bowler==0.8.0
CacheControl==0.12.10
cachy==0.3.0
celery==4.4.1
Cerberus==1.3.2
certifi==2021.10.8
cffi==1.15.0
chardet==3.0.4
charset-normalizer==2.0.10
cleo==0.8.1
click==7.1.2
clikit==0.6.2
coverage==5.0.3
crashtest==0.3.1
cryptography==36.0.1
dephell==0.8.3
dephell-archive==0.1.6
dephell-argparse==0.1.2
dephell-changelogs==0.0.1
dephell-discover==0.2.10
dephell-licenses==0.1.6
dephell-links==0.1.5
dephell-markers==1.0.3
dephell-pythons==0.1.14
dephell-setuptools==0.2.3
dephell-shells==0.1.4
dephell-specifier==0.2.2
dephell-venvs==0.1.17
dephell-versioning==0.1.1
distlib==0.3.4
docker==2.7.0
docker-pycreds==0.4.0
dockerpty==0.4.1
docutils==0.16
entrypoints==0.3
execnet==1.7.1
filelock==3.4.2
fissix==19.2b1
flake8==3.7.9
flatdict==4.0.1
frozenlist==1.3.0
graphviz==0.14
html5lib==1.0.1
idna==2.9
isort==4.3.21
jeepney==0.7.1
Jinja2==2.11.2
keyring==21.8.0
kombu==4.6.8
lazy-object-proxy==1.4.3
lockfile==0.12.2
m2r==0.2.1
MarkupSafe==1.1.1
mccabe==0.6.1
mistune==0.8.4
more-itertools==8.2.0
moreorless==0.4.0
msgpack==1.0.3
multidict==4.7.5
numpy==1.18.1
packaging==20.3
pastel==0.2.1
pathspec==0.7.0
pexpect==4.8.0
pkginfo==1.8.2
platformdirs==2.4.1
pluggy==0.13.1
poetry==1.1.12
poetry-core==1.0.7
preggy==1.4.4
ptyprocess==0.6.0
py==1.8.1
pycodestyle==2.5.0
pycparser==2.21
pyflakes==2.1.1
Pygments==2.6.1
pylev==1.4.0
pylint==2.4.4
pyparsing==2.4.7
pyres==1.5
pytest==5.4.1
pytest-asyncio==0.10.0
pytest-cov==2.8.1
pytest-forked==1.1.3
pytest-tldr==0.2.1
pytest-xdist==1.31.0
python-gnupg==0.4.6
pytz==2019.3
redis==3.4.1
regex==2020.2.20
requests==2.23.0
requests-mock==1.7.0
requests-toolbelt==0.9.1
ruamel.yaml==0.16.10
ruamel.yaml.clib==0.2.0
SecretStorage==3.3.1
sentry-sdk==1.5.4
setproctitle==1.1.10
sh==1.13.0
shellingham==1.3.2
simplejson==3.17.0
six==1.14.0
tabulate==0.8.7
termcolor==1.1.0
toml==0.10.0
tomlkit==0.6.0
typed-ast==1.4.1
Unidecode==1.1.1
urllib3==1.26.8
vine==1.3.0
virtualenv==20.13.0
volatile==2.1.0
wcwidth==0.1.9
webencodings==0.5.1
websocket-client==0.57.0
wrapt==1.11.2
yapf==0.30.0
yarl==1.4.2
yaspin==0.16.0
```