### PR TITLE
added redis sentinel support

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -20,4 +20,4 @@ jobs:
         run: sudo apt update && sudo apt install -y libjpeg-dev python3-opencv
       - name: Install pip dependencies
         run: make setup
-      - run: make unit
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+REDIS_CONTAINER := redis-test redis-sentinel-test
+
 setup:
 	@pip install -Ue .[dev]
 
 run:
 	@remotecv
+
+test: run-redis unit stop-redis
 
 unit:
 	@pytest --cov=remotecv --cov-report term-missing --asyncio-mode=strict -r tests/
@@ -15,3 +19,9 @@ pylint:
 
 ci-test:
 	@if [ "$$LINT_TEST" ]; then $(MAKE) flake; else $(MAKE) unit; fi
+
+run-redis:
+	@docker-compose up -d $(REDIS_CONTAINER)
+
+stop-redis:
+	@docker-compose stop $(REDIS_CONTAINER)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.8"
+
+services:
+  redis-test:
+    image: "redis:6.2-alpine"
+    ports:
+      - 6379:6379
+
+  redis-sentinel-test:
+    build:
+      context: ./tests/fixtures/redis-sentinel
+    ports:
+      - 6380:6380
+      - 6381:6381
+      - 6382:6382
+      - 6383:6383
+      - 26379:26379
+      - 26380:26380

--- a/remotecv/result_store/redis_store.py
+++ b/remotecv/result_store/redis_store.py
@@ -1,7 +1,5 @@
-from redis import Redis
-
 from remotecv.result_store import BaseStore
-from remotecv.utils import logger
+from remotecv.utils import logger, redis_client
 
 
 class ResultStore(BaseStore):
@@ -13,12 +11,7 @@ class ResultStore(BaseStore):
         super().__init__(config)
 
         if not ResultStore.redis_instance:
-            ResultStore.redis_instance = Redis(
-                host=config.redis_host,
-                port=config.redis_port,
-                db=config.redis_database,
-                password=config.redis_password,
-            )
+            ResultStore.redis_instance = redis_client()
         self.storage = ResultStore.redis_instance
 
     def store(self, key, points):

--- a/remotecv/utils.py
+++ b/remotecv/utils.py
@@ -10,6 +10,8 @@
 
 import logging
 
+from redis import Redis, Sentinel
+
 
 class Config:
     pass
@@ -17,3 +19,55 @@ class Config:
 
 logger = logging.getLogger("remotecv")  # pylint: disable=invalid-name
 config = Config()  # pylint: disable=invalid-name
+
+SINGLE_NODE = "single_node"
+SENTINEL = "sentinel"
+
+
+def redis_client():
+    if config.redis_mode == SINGLE_NODE:
+        return __redis_single_node_client()
+
+    if config.redis_mode == SENTINEL:
+        return __redis_sentinel_client()
+
+    raise AttributeError(f"redis-mode must be either {SINGLE_NODE} or {SENTINEL}")
+
+
+def __redis_sentinel_client():
+    instances_split = config.redis_sentinel_instances.split(",")
+    instances = [instance.split(":") for instance in instances_split]
+
+    if config.redis_sentinel_password:
+        sentinel_instance = Sentinel(
+            instances,
+            socket_timeout=config.redis_sentinel_socket_timeout,
+            sentinel_kwargs={"password": config.redis_sentinel_password},
+        )
+    else:
+        sentinel_instance = Sentinel(
+            instances,
+            socket_timeout=config.redis_sentinel_socket_timeout,
+        )
+
+    return sentinel_instance.master_for(
+        config.redis_sentinel_master_instance,
+        socket_timeout=config.redis_sentinel_socket_timeout,
+        password=config.redis_sentinel_master_password,
+    )
+
+
+def __redis_single_node_client():
+    if config.redis_password:
+        return Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            db=config.redis_database,
+            password=config.redis_password,
+        )
+
+    return Redis(
+        host=config.redis_host,
+        port=config.redis_port,
+        db=config.redis_database,
+    )

--- a/tests/fixtures/redis-sentinel/Dockerfile
+++ b/tests/fixtures/redis-sentinel/Dockerfile
@@ -1,0 +1,33 @@
+FROM redis:6-alpine
+
+ENV MASTER_INSTANCE redismaster
+ENV MASTER_PORT 6380
+ENV MASTER_SECURE_INSTANCE redissecuremaster
+ENV MASTER_SECURE_PASSWORD superpassword
+ENV MASTER_SECURE_PORT 6381
+ENV SENTINEL_DOWN_AFTER 1000
+ENV SENTINEL_FAILOVER 1000
+ENV SENTINEL_PASSWORD superpassword
+ENV SENTINEL_QUORUM 2
+ENV SLAVE_PORT 6382
+ENV SLAVE_SECURE_PORT 6383
+
+RUN mkdir -p /redis
+
+WORKDIR /redis
+
+COPY sentinel.conf .
+COPY sentinel-secure.conf .
+COPY sentinel-entrypoint.sh /usr/local/bin/
+
+RUN chown redis:redis /redis/* && \
+    chmod +x /usr/local/bin/sentinel-entrypoint.sh
+
+EXPOSE 26379
+EXPOSE 26380
+EXPOSE 6380
+EXPOSE 6381
+EXPOSE 6382
+EXPOSE 6383
+
+ENTRYPOINT ["sentinel-entrypoint.sh"]

--- a/tests/fixtures/redis-sentinel/sentinel-entrypoint.sh
+++ b/tests/fixtures/redis-sentinel/sentinel-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+sed -i "s/MASTER_INSTANCE/$MASTER_INSTANCE/g" /redis/sentinel.conf
+sed -i "s/MASTER_PORT/$MASTER_PORT/g" /redis/sentinel.conf
+sed -i "s/SENTINEL_DOWN_AFTER/$SENTINEL_DOWN_AFTER/g" /redis/sentinel.conf
+sed -i "s/SENTINEL_FAILOVER/$SENTINEL_FAILOVER/g" /redis/sentinel.conf
+sed -i "s/SENTINEL_QUORUM/$SENTINEL_QUORUM/g" /redis/sentinel.conf
+
+sed -i "s/MASTER_INSTANCE/$MASTER_INSTANCE/g" /redis/sentinel-secure.conf
+sed -i "s/MASTER_PORT/$MASTER_PORT/g" /redis/sentinel-secure.conf
+sed -i "s/SENTINEL_DOWN_AFTER/$SENTINEL_DOWN_AFTER/g" /redis/sentinel-secure.conf
+sed -i "s/SENTINEL_FAILOVER/$SENTINEL_FAILOVER/g" /redis/sentinel-secure.conf
+sed -i "s/SENTINEL_PASSWORD/$SENTINEL_PASSWORD/g" /redis/sentinel-secure.conf
+sed -i "s/SENTINEL_QUORUM/$SENTINEL_QUORUM/g" /redis/sentinel-secure.conf
+
+# Master
+redis-server --port $MASTER_PORT &
+
+# Slave
+redis-server --port $SLAVE_PORT --slaveof localhost $MASTER_PORT &
+
+# Sentinel
+redis-server /redis/sentinel.conf --sentinel &
+redis-server /redis/sentinel-secure.conf --sentinel &
+
+wait -n

--- a/tests/fixtures/redis-sentinel/sentinel-secure.conf
+++ b/tests/fixtures/redis-sentinel/sentinel-secure.conf
@@ -1,0 +1,11 @@
+port 26380
+
+dir /tmp
+
+requirepass SENTINEL_PASSWORD
+sentinel resolve-hostnames yes
+sentinel announce_hostnames yes
+sentinel monitor MASTER_INSTANCE localhost MASTER_PORT SENTINEL_QUORUM
+sentinel down-after-milliseconds MASTER_INSTANCE SENTINEL_DOWN_AFTER
+sentinel parallel-syncs MASTER_INSTANCE 1
+sentinel failover-timeout MASTER_INSTANCE SENTINEL_FAILOVER

--- a/tests/fixtures/redis-sentinel/sentinel.conf
+++ b/tests/fixtures/redis-sentinel/sentinel.conf
@@ -1,0 +1,9 @@
+port 26379
+
+dir /tmp
+
+sentinel resolve-hostnames yes
+sentinel monitor MASTER_INSTANCE localhost MASTER_PORT SENTINEL_QUORUM
+sentinel down-after-milliseconds MASTER_INSTANCE SENTINEL_DOWN_AFTER
+sentinel parallel-syncs MASTER_INSTANCE 1
+sentinel failover-timeout MASTER_INSTANCE SENTINEL_FAILOVER

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+
+from preggy import expect
+
+from remotecv.utils import config, redis_client
+
+
+class RedisSingleNodeClientTestCase(TestCase):
+    def test_should_connect_to_redis_single_node(self):
+        config.redis_host = "localhost"
+        config.redis_port = 6379
+        config.redis_database = 0
+        config.redis_password = "superpassword"
+        config.redis_mode = "single_node"
+
+        client = redis_client()
+
+        expect(client).not_to_be_null()
+        expect(str(client)).to_equal(
+            "Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>"
+        )
+
+    def test_should_connect_to_redis_single_node_no_pass(self):
+        config.redis_host = "localhost"
+        config.redis_port = 6380
+        config.redis_database = 0
+        config.redis_password = None
+        config.redis_mode = "single_node"
+
+        client = redis_client()
+        expect(client).not_to_be_null()
+        expect(str(client)).to_equal(
+            "Redis<ConnectionPool<Connection<host=localhost,port=6380,db=0>>>"
+        )
+
+
+class RedisSentinelClientTestCase(TestCase):
+    def test_should_connect_to_redis_sentinel(self):
+        config.redis_mode = "sentinel"
+        config.redis_sentinel_instances = "localhost:26380"
+        config.redis_sentinel_password = "superpassword"
+        config.redis_sentinel_master_instance = "redismaster"
+        config.redis_sentinel_master_password = None
+        config.redis_sentinel_socket_timeout = 10.0
+
+        client = redis_client()
+        expect(client).not_to_be_null()
+        expect(str(client)).to_equal(
+            "Redis<SentinelConnectionPool<service=redismaster(master)>"
+        )
+
+    def test_should_connect_to_redis_sentinel_no_pass(self):
+        config.redis_mode = "sentinel"
+        config.redis_sentinel_instances = "localhost:26379"
+        config.redis_sentinel_password = None
+        config.redis_sentinel_master_instance = "redismaster"
+        config.redis_sentinel_master_password = None
+        config.redis_sentinel_socket_timeout = 10.0
+
+        client = redis_client()
+        expect(client).not_to_be_null()
+        expect(str(client)).to_equal(
+            "Redis<SentinelConnectionPool<service=redismaster(master)>"
+        )
+
+
+class RedisNoneClientTestCase(TestCase):
+    def test_should_return_none(self):
+        config.redis_mode = None
+
+        with self.assertRaises(AttributeError) as err:
+            client = redis_client()
+
+        expect(str(err.exception)).to_equal(
+            "redis-mode must be either single_node or sentinel"
+        )


### PR DESCRIPTION
Added Redis Sentinel support.

To connect into sentinel cluster:

```sh 
remotecv --redis-mode=sentinel --sentinel-instances=localhost:23679,localhost:23680,localhost:23681 --sentinel-password=password --master-instance=mastersentinel --socket-timeout=10.0
```

To test locally you can use:

```sh
make run-redis 
make stop-redis
# or
make test # will run all unit tests
```

The parameter `--redis-mode` is optional, with default value of `single-node`, so you still can use normal Remotecv command.
