### PR TITLE
add-grayscale-equalized

### DIFF
--- a/remotecv/detectors/__init__.py
+++ b/remotecv/detectors/__init__.py
@@ -49,8 +49,17 @@ class CascadeLoaderDetector(BaseDetector):
     def get_features(self, image):
         img = self.get_np_img(image)
 
+        return self.get_faces(img, image.size)
+
+    def get_grayscale_equalized_features(self, image):
+        img = self.get_np_img(image)
+        img_equalized = cv2.equalizeHist(cv2.cvtColor(img, cv2.COLOR_BGR2GRAY))
+
+        return self.get_faces(img_equalized, image.size)
+
+    def get_faces(self, image, image_size):
         faces = self.__class__.cascade.detectMultiScale(
-            img, 1.2, 4, minSize=self.get_min_size_for(image.size)
+            image, 1.2, 4, minSize=self.get_min_size_for(image_size)
         )
         faces_scaled = []
 

--- a/remotecv/detectors/complete_detector/__init__.py
+++ b/remotecv/detectors/complete_detector/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # thumbor imaging service

--- a/remotecv/detectors/face_detector/__init__.py
+++ b/remotecv/detectors/face_detector/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # thumbor imaging service
@@ -6,7 +5,7 @@
 
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license
-# Copyright (c) 2011 globo.com timehome@corp.globo.com
+# Copyright (c) 2011 globo.com <thumbor@g.globo>
 
 from remotecv.detectors import CascadeLoaderDetector
 
@@ -22,7 +21,7 @@ class FaceDetector(CascadeLoaderDetector):
         return top
 
     def detect(self, image):
-        features = self.get_features(image)
+        features = self.get_grayscale_equalized_features(image)
         points = []
         if features:
             for (left, top, width, height), _neighbors in features:


### PR DESCRIPTION
Added new face detector, the 'face_grayscale_equalized_detector'. 

This detector can be used as the 'face_detector', but it is not part of the 'all', this happens so as not to change the use of whom I have the 'all' instantiated.

[Issue](https://github.com/thumbor/remotecv/issues/59)