### PR TITLE
Makes extensible metrics in remotecv

### DIFF
--- a/remotecv/http_loader.py
+++ b/remotecv/http_loader.py
@@ -1,9 +1,30 @@
 import re
+
 from urllib.request import unquote, urlopen
+from urllib.parse import urlparse
+from remotecv.timing import get_time, get_interval
+from remotecv.utils import context
 
 
 def load_sync(path):
+    start_time = get_time()
     if not re.match(r"^https?", path):
         path = f"http://{path}"
     path = unquote(path)
-    return urlopen(path).read()
+    netloc = urlparse(path).netloc.replace(".", "_")
+    response = urlopen(path)
+    code = response.code
+    result = response.read()
+
+    context.metrics.incr("worker.original_image.response_bytes", len(result))
+    context.metrics.timing(
+        f"worker.original_image.fetch.{code}.{netloc}",
+        get_interval(start_time, get_time()),
+    )
+    context.metrics.incr(
+        f"worker.original_image.fetch.{code}.{netloc}",
+    )
+    context.metrics.incr(f"worker.original_image.status.{code}")
+    context.metrics.incr(f"worker.original_image.status.{code}.{netloc}")
+
+    return result

--- a/remotecv/importer.py
+++ b/remotecv/importer.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022, globo.com <thumbor@g.globo>
+
+from importlib import import_module
+
+
+class Importer:
+    @classmethod
+    def import_class(cls, class_name, conf_value):
+        module = import_module(conf_value)
+        return getattr(module, class_name)

--- a/remotecv/metrics/__init__.py
+++ b/remotecv/metrics/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022, globo.com <thumbor@g.globo>
+
+
+class BaseMetrics:
+    def __init__(self, config):
+        self.config = config
+
+    def initialize(self):
+        pass
+
+    def incr(self, metricname, value=1):
+        raise NotImplementedError()
+
+    def timing(self, metricname, value):
+        raise NotImplementedError()

--- a/remotecv/metrics/logger_metrics.py
+++ b/remotecv/metrics/logger_metrics.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022, globo.com <thumbor@g.globo>
+
+from remotecv.metrics import BaseMetrics
+from remotecv.utils import logger
+
+
+class Metrics(BaseMetrics):
+    def incr(self, metricname, value=1):
+        logger.debug("METRICS: inc: %s:%d", metricname, value)
+
+    def timing(self, metricname, value):
+        logger.debug("METRICS: timing: %s:%d", metricname, value)

--- a/remotecv/pyres_tasks.py
+++ b/remotecv/pyres_tasks.py
@@ -1,5 +1,6 @@
 from remotecv.image_processor import ImageProcessor
-from remotecv.utils import config, logger
+from remotecv.timing import get_time, get_interval
+from remotecv.utils import config, logger, context
 
 # pylint: disable=no-member
 
@@ -10,8 +11,15 @@ class DetectTask:
 
     @classmethod
     def perform(cls, detection_type, image_path, key):
+        start_time = get_time()
         logger.info("Detecting %s for %s", detection_type, image_path)
         image_data = config.loader.load_sync(image_path)
         points = cls.processor.detect(detection_type, image_data)
         result_store = config.store.ResultStore(config)
         result_store.store(key, points)
+
+        context.metrics.timing(
+            "worker.pyres_task.time",
+            get_interval(start_time, get_time()),
+        )
+        context.metrics.incr("worker.pyres_task.total")

--- a/remotecv/timing.py
+++ b/remotecv/timing.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2022, globo.com <thumbor@g.globo>
+
+import time
+
+
+def get_time():
+    return time.perf_counter_ns()
+
+
+def get_interval(start, end):
+    return nano_to_ms(end - start)
+
+
+def nano_to_ms(ns_time):
+    return ns_time / 1e6

--- a/remotecv/utils.py
+++ b/remotecv/utils.py
@@ -17,8 +17,13 @@ class Config:
     pass
 
 
+class Context:
+    pass
+
+
 logger = logging.getLogger("remotecv")  # pylint: disable=invalid-name
 config = Config()  # pylint: disable=invalid-name
+context = Context()
 
 SINGLE_NODE = "single_node"
 SENTINEL = "sentinel"

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "remotecv.detectors.feature_detector",
         "remotecv.detectors.glasses_detector",
         "remotecv.detectors.profile_detector",
+        "remotecv.metrics",
         "remotecv.result_store",
     ],
     package_dir={"": "."},

--- a/tests/test_complete_detector.py
+++ b/tests/test_complete_detector.py
@@ -1,16 +1,18 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from preggy import expect
 
 from remotecv.detectors.complete_detector import CompleteDetector
+from remotecv.utils import context
 from tests import create_image
 
 
 class CompleteDetectorTestCase(TestCase):
     def test_should_detect_something(self):
+        context.metrics = mock.Mock()
         detection_result = CompleteDetector().detect(create_image("profile_face.jpg"))
         expect(len(detection_result)).to_be_greater_than(20)
         expect(detection_result[0][0]).to_be_numeric()

--- a/tests/test_face_detector.py
+++ b/tests/test_face_detector.py
@@ -1,15 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from preggy import expect
 
 from remotecv.detectors.face_detector import FaceDetector
+from remotecv.utils import context
 from tests import create_image
 
 
 class FaceDetectorTestCase(TestCase):
+    def setUp(self):
+        context.metrics = mock.Mock()
+
     def test_should_detect_one_face(self):
         detection_result = FaceDetector().detect(create_image("one_face.jpg"))
         expect(detection_result).to_length(1)

--- a/tests/test_feature_detector.py
+++ b/tests/test_feature_detector.py
@@ -1,15 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from preggy import expect
 
 from remotecv.detectors.feature_detector import FeatureDetector
+from remotecv.utils import context
 from tests import create_image
 
 
 class FeatureDetectorTestCase(TestCase):
+    def setUp(self):
+        context.metrics = mock.Mock()
+
     def test_should_detect_multiple_points(self):
         detection_result = FeatureDetector().detect(create_image("no_face.jpg"))
         expect(len(detection_result)).to_be_greater_than(4)

--- a/tests/test_glasses_detector.py
+++ b/tests/test_glasses_detector.py
@@ -1,15 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from preggy import expect
 
 from remotecv.detectors.glasses_detector import GlassesDetector
+from remotecv.utils import context
 from tests import create_image
 
 
 class GlassesDetectorTestCase(TestCase):
+    def setUp(self):
+        context.metrics = mock.Mock()
+
     def test_should_detect_glasses(self):
         detection_result = GlassesDetector().detect(create_image("glasses.jpg"))
         expect(detection_result).to_length(2)

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,12 +1,16 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from preggy import expect
 
 from remotecv.image_processor import ImageProcessor
+from remotecv.utils import context
 from tests import read_fixture
 
 
 class ImageProcessorTest(TestCase):
+    def setUp(self):
+        context.metrics = mock.Mock()
+
     def test_when_detector_unavailable(self):
         image_processor = ImageProcessor()
         with expect.error_to_happen(AttributeError):

--- a/tests/test_profile_detector.py
+++ b/tests/test_profile_detector.py
@@ -1,15 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from preggy import expect
 
 from remotecv.detectors.profile_detector import ProfileDetector
+from remotecv.utils import context
 from tests import create_image
 
 
 class ProfileDetectorTestCase(TestCase):
+    def setUp(self):
+        context.metrics = mock.Mock()
+
     def test_should_detect_one_face(self):
         detection_result = ProfileDetector().detect(create_image("profile_face.jpg"))
         expect(detection_result).to_length(1)

--- a/tests/test_pyres_tasks.py
+++ b/tests/test_pyres_tasks.py
@@ -6,7 +6,7 @@ from unittest import TestCase, mock
 from preggy import expect
 
 from remotecv.pyres_tasks import DetectTask
-from remotecv.utils import config
+from remotecv.utils import config, context
 from tests import read_fixture
 
 
@@ -16,6 +16,7 @@ class DetectTaskTestCase(TestCase):
         config.loader = mock.Mock(load_sync=read_fixture)
         config.store = store_mock
         config.store.ResultStore = mock.Mock(return_value=store_mock)
+        context.metrics = mock.Mock()
         DetectTask.perform("all", "group-smile-bw.jpg", "test-key")
         call = store_mock.store.call_args[0]
 


### PR DESCRIPTION
This PR aims to create metrics for remotecv and make it extensive for defining upstream metrics. So was added the metrics bellow:


For each detector:
 - latency (ms) - (worker.face.time, worker.feature.time, worker.glasses.time, worker.profile.time)
 - detected (if found points) - (worker.face.detected, worker.feature.detected, worker.glasses.detected, worker.profile.detected) 

For original image, such as Thumbor does:
- response_bytes - (worker.original_image.response_bytes)
- status_code + host + latency - (worker.original_image.fetch.{code}.{netloc})
- status_code + host + count - (worker.original_image.fetch.{code}.{netloc})
- status_code + count - (worker.original_image.status.{code})

For each task (image to detect):
- time (total time of detection) - (worker.pyres_task.time, worker.celery_task.time)
- count - (worker.pyres_task.total, worker.celery_task.total)


closes https://github.com/thumbor/remotecv/issues/60