### PR TITLE
Fix-file-training-face-detector

### DIFF
--- a/remotecv/detectors/face_detector/__init__.py
+++ b/remotecv/detectors/face_detector/__init__.py
@@ -14,7 +14,7 @@ HAIR_OFFSET = 0.12
 
 class FaceDetector(CascadeLoaderDetector):
     def __init__(self):
-        self.load_cascade_file(__file__, "haarcascade_frontalface_alt.xml")
+        self.load_cascade_file(__file__, "haarcascade_frontalface_default.xml")
 
     def __add_hair_offset(self, top, height):
         top = max(0, top - height * HAIR_OFFSET)


### PR DESCRIPTION
In [PR](https://github.com/thumbor/remotecv/pull/62), when the detector was unified, it kept the old training file.