### PR TITLE
Add custom redis key expiration time

### DIFF
--- a/remotecv/result_store/redis_store.py
+++ b/remotecv/result_store/redis_store.py
@@ -4,7 +4,6 @@ from remotecv.utils import logger, redis_client
 
 class ResultStore(BaseStore):
 
-    WEEK = 604800
     redis_instance = None
 
     def __init__(self, config):
@@ -12,14 +11,16 @@ class ResultStore(BaseStore):
 
         if not ResultStore.redis_instance:
             ResultStore.redis_instance = redis_client()
+
+        self.redis_key_expire_time = config.redis_key_expire_time
         self.storage = ResultStore.redis_instance
 
     def store(self, key, points):
         result = self.serialize(points)
         logger.debug("Points found: %s", result)
         redis_key = f"thumbor-detector-{key}"
-        self.storage.setex(
+        self.storage.set(
             name=redis_key,
             value=result,
-            time=2 * self.WEEK,
+            ex=self.redis_key_expire_time,
         )

--- a/remotecv/worker.py
+++ b/remotecv/worker.py
@@ -124,6 +124,13 @@ def import_modules():
     help="Redis mode",
 )
 @optgroup.option(
+    "--redis-key-expire-time",
+    envvar="REDIS_KEY_EXPIRE_TIME",
+    show_envvar=True,
+    default=1209600,
+    help="Redis key expiration time in seconds",
+)
+@optgroup.option(
     "--sentinel-instances",
     envvar="REDIS_SENTINEL_INSTANCES",
     show_envvar=True,
@@ -293,6 +300,7 @@ def main(**params):
     config.redis_database = params["database"]
     config.redis_password = params["password"]
     config.redis_mode = params["redis_mode"]
+    config.redis_key_expire_time = params["redis_key_expire_time"]
     config.redis_sentinel_instances = params["sentinel_instances"]
     config.redis_sentinel_password = params["sentinel_password"]
     config.redis_sentinel_socket_timeout = params["socket_timeout"]

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+import time
+
+from thumbor.testing import TestCase
+from tornado.testing import gen_test
+from preggy import expect
+
+from remotecv.result_store.redis_store import ResultStore
+from remotecv.utils import config, redis_client
+
+
+class RedisStorageTestCase(TestCase):
+    @gen_test
+    async def test_should_be_none_when_not_available(self):
+        config.redis_host = "localhost"
+        config.redis_port = 6379
+        config.redis_database = 0
+        config.redis_password = None
+        config.redis_mode = "single_node"
+        config.redis_key_expire_time = 2
+        points = [[0, 1, 2, 3], [0, 2, 3, 4]]
+        client = redis_client()
+
+        result_store = ResultStore(config)
+
+        value = client.get("thumbor-detector-key")
+        expect(value).to_be_null()
+
+        result_store.store("key", points)
+
+        value = client.get("thumbor-detector-key")
+        points_serialized = (b'[{"x": 1.0, "y": 2.5, "height": 2,' +
+                             b' "width": 3, "origin": "", "z": 6},' +
+                             b' {"x": 1.5, "y": 4.0, ' +
+                             b'"height": 3, "width": 4, ' +
+                             b'"origin": "", "z": 12}]')
+        expect(value).to_equal(points_serialized)
+
+        time.sleep(3)
+
+        value = client.get("thumbor-detector-key")
+        expect(value).to_be_null()


### PR DESCRIPTION
This PR aims to make the redis key expiry time setting customizable. Keeping default time in two weeks.

ps: [the setex command from redis is deprecated](https://redis.io/commands/setex/), so i took the opportunity to migrate :) 