### PR TITLE
Add worker TTL

### DIFF
--- a/remotecv/unique_queue.py
+++ b/remotecv/unique_queue.py
@@ -2,7 +2,7 @@ from pyres import ResQ
 from pyres.worker import Worker
 
 from remotecv.timing import get_time, get_interval
-from remotecv.utils import context, logger
+from remotecv.utils import config, context, logger
 
 
 class UniqueQueue(ResQ):
@@ -84,3 +84,10 @@ class UniqueWorker(Worker):
             get_interval(start_time, get_time()),
         )
         return job
+
+    def register_worker(self):
+        super().register_worker()
+        if config.worker_ttl:
+            self.resq.redis.expire(
+                f"resque:worker:{str(self)}:started", config.worker_ttl
+            )

--- a/remotecv/worker.py
+++ b/remotecv/worker.py
@@ -268,6 +268,14 @@ def import_modules():
     help="Timeout in seconds for image detection",
 )
 @optgroup.option(
+    "--worker-ttl",
+    envvar="WORKER_TTL",
+    show_envvar=True,
+    default=None,
+    type=click.INT,
+    help="TTL in seconds for worker",
+)
+@optgroup.option(
     "--sentry-url",
     envvar="SENTRY_URL",
     show_envvar=True,
@@ -314,6 +322,7 @@ def main(**params):
     config.polling_interval = params["polling_interval"]
 
     config.timeout = params["timeout"]
+    config.worker_ttl = params["worker_ttl"]
     config.server_port = params["server_port"]
     config.log_level = params["level"].upper()
     config.loader = import_module(params["loader"])


### PR DESCRIPTION
When remotecv is killed in kubernetes/docker the environment stay with dead instances. So this PR aims to add a worker TTL configuration to avoid this problem.