### PR TITLE
Prune dead members on startup

### DIFF
--- a/remotecv/unique_queue.py
+++ b/remotecv/unique_queue.py
@@ -91,3 +91,9 @@ class UniqueWorker(Worker):
             self.resq.redis.expire(
                 f"resque:worker:{str(self)}:started", config.worker_ttl
             )
+
+    def startup(self):
+        if config.prune_dead_members:
+            self.resq.redis.delete("resque:workers")
+
+        super().startup()

--- a/remotecv/worker.py
+++ b/remotecv/worker.py
@@ -276,6 +276,14 @@ def import_modules():
     help="TTL in seconds for worker",
 )
 @optgroup.option(
+    "--prune-dead-members",
+    envvar="PRUNE_DEAD_MEMBERS",
+    show_envvar=True,
+    is_flag=True,
+    default=False,
+    help="Prune dead members on startup",
+)
+@optgroup.option(
     "--sentry-url",
     envvar="SENTRY_URL",
     show_envvar=True,
@@ -323,6 +331,7 @@ def main(**params):
 
     config.timeout = params["timeout"]
     config.worker_ttl = params["worker_ttl"]
+    config.prune_dead_members = params["prune_dead_members"]
     config.server_port = params["server_port"]
     config.log_level = params["level"].upper()
     config.loader = import_module(params["loader"])


### PR DESCRIPTION
When remotecv is killed in kubernetes/docker the environment stay with dead members instances. So this PR aims to add a prune dead members configuration to avoid this problem.

continuation of https://github.com/thumbor/remotecv/pull/78 😬