### PR TITLE
Add Black as part of the linting process

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Run Unit Tests
         run: make unit
       - name: Lint
-        run: make flake pylint
+        run: make lint
       - name: Generate lcov
         run: make coverage
       - name: Coveralls

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,16 @@ coverage:
 	@coverage report -m --fail-under=52
 	@coverage lcov
 
+black:
+	@black . --config pyproject.toml
+
 flake:
 	@flake8 --config .flake8
 
 pylint:
 	@pylint remotecv tests
+
+lint: black flake pylint
 
 ci-test:
 	@if [ "$$LINT_TEST" ]; then $(MAKE) flake; else $(MAKE) unit; fi

--- a/remotecv/healthcheck.py
+++ b/remotecv/healthcheck.py
@@ -10,4 +10,4 @@ class HealthCheckHandler(BaseHTTPRequestHandler):
         self.wfile.write(b"WORKING")
 
     def log_message(self, format, *args):  # pylint: disable=redefined-builtin
-        logging.info(format.replace('\"', ""), *args)
+        logging.info(format.replace('"', ""), *args)

--- a/remotecv/utils.py
+++ b/remotecv/utils.py
@@ -43,7 +43,8 @@ def redis_client():
         )
 
     context.metrics.timing(
-        "worker.redis_connection.time", get_interval(start_time, get_time()),
+        "worker.redis_connection.time",
+        get_interval(start_time, get_time()),
     )
 
     return client

--- a/remotecv/worker.py
+++ b/remotecv/worker.py
@@ -308,7 +308,10 @@ def import_modules():
 def main(**params):
     """Runs RemoteCV"""
 
-    logging.basicConfig(level=getattr(logging, params["level"].upper()), format=params["format"])
+    logging.basicConfig(
+        level=getattr(logging, params["level"].upper()),
+        format=params["format"],
+    )
 
     config.backend = params["backend"]
     config.redis_host = params["host"]

--- a/tests/test_face_detector.py
+++ b/tests/test_face_detector.py
@@ -77,21 +77,27 @@ class FaceDetectorTestCase(TestCase):
         expect(detection_result[0][3]).to_be_numeric()
 
     def test_should_run_on_images_with_mode_l(self):
-        detection_result = FaceDetector().detect(create_image("one_face-bw.png"))
+        detection_result = FaceDetector().detect(
+            create_image("one_face-bw.png")
+        )
         expect(detection_result[0][0]).to_be_numeric()
         expect(detection_result[0][1]).to_be_numeric()
         expect(detection_result[0][2]).to_be_numeric()
         expect(detection_result[0][3]).to_be_numeric()
 
     def test_should_run_on_images_with_mode_1(self):
-        detection_result = FaceDetector().detect(create_image("one_face-bw-1.png"))
+        detection_result = FaceDetector().detect(
+            create_image("one_face-bw-1.png")
+        )
         expect(detection_result[0][0]).to_be_numeric()
         expect(detection_result[0][1]).to_be_numeric()
         expect(detection_result[0][2]).to_be_numeric()
         expect(detection_result[0][3]).to_be_numeric()
 
     def test_should_run_on_images_with_mode_la(self):
-        detection_result = FaceDetector().detect(create_image("one_face-bw-la.png"))
+        detection_result = FaceDetector().detect(
+            create_image("one_face-bw-la.png")
+        )
         expect(detection_result[0][0]).to_be_numeric()
         expect(detection_result[0][1]).to_be_numeric()
         expect(detection_result[0][2]).to_be_numeric()

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -6,9 +6,9 @@ import uuid
 
 from redis import RedisError
 
-from thumbor.testing import TestCase
 from tornado.testing import gen_test
 from preggy import expect
+from thumbor.testing import TestCase
 
 import remotecv.storages.redis_storage
 

--- a/tests/test_result_store.py
+++ b/tests/test_result_store.py
@@ -6,16 +6,15 @@ import time
 import json
 from unittest import mock
 
-from thumbor.testing import TestCase
 from tornado.testing import gen_test
 from preggy import expect
+from thumbor.testing import TestCase
 
 from remotecv.result_store.redis_store import ResultStore
 from remotecv.utils import context, config, redis_client
 
 
 class RedisStorageTestCase(TestCase):
-
     @gen_test
     async def test_should_be_none_when_not_available(self):
         config.redis_host = "localhost"
@@ -34,24 +33,26 @@ class RedisStorageTestCase(TestCase):
         result_store.store("key", points)
 
         value = client.get("thumbor-detector-key")
-        points_serialized = json.dumps([
-            {
-                "x": 1.0,
-                "y": 2.5,
-                "height": 2,
-                "width": 3,
-                "origin": "",
-                "z": 6,
-            },
-            {
-                "x": 1.5,
-                "y": 4.0,
-                "height": 3,
-                "width": 4,
-                "origin": "",
-                "z": 12,
-            },
-        ])
+        points_serialized = json.dumps(
+            [
+                {
+                    "x": 1.0,
+                    "y": 2.5,
+                    "height": 2,
+                    "width": 3,
+                    "origin": "",
+                    "z": 6,
+                },
+                {
+                    "x": 1.5,
+                    "y": 4.0,
+                    "height": 3,
+                    "width": 4,
+                    "origin": "",
+                    "z": 12,
+                },
+            ]
+        )
 
         expect(value).to_equal(points_serialized)
 


### PR DESCRIPTION
Black is ran by pre-commit hook, and therefore should be ran when linting as well, otherwise it leads to inconsistencies — which are fixed by this very CL.